### PR TITLE
Change "minutes" for "h min" in recipe details

### DIFF
--- a/app/src/main/java/org/easyrecipe/features/recipedetail/RecipeDetailFragment.kt
+++ b/app/src/main/java/org/easyrecipe/features/recipedetail/RecipeDetailFragment.kt
@@ -109,7 +109,7 @@ class RecipeDetailFragment : BaseFragment() {
 
         typeDetailList.bringToFront()
 
-        recipeDetailTime.text = getString(R.string.recipe_detail_time, recipe.time)
+        recipeDetailTime.text = recipe.time.toDurationString()
 
         ingredientDetailListAdapter = IngredientDetailListAdapter()
         ingredientDetailList.adapter = ingredientDetailListAdapter
@@ -214,6 +214,17 @@ class RecipeDetailFragment : BaseFragment() {
         btnCheckSteps.visibility = View.VISIBLE
         btnCheckSteps.setOnClickListener {
             checkStepsLauncher.launch(remoteRecipe.url)
+        }
+    }
+
+    private fun Int.toDurationString(): String {
+        val hours = div(60)
+        val minutes = mod(60)
+
+        return when {
+            hours < 1 -> getString(R.string.recipe_detail_minute_time, minutes)
+            minutes > 1 -> getString(R.string.recipe_detail_hour_minute_time, hours, minutes)
+            else -> getString(R.string.recipe_detail_hour_time, hours)
         }
     }
 }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -63,7 +63,9 @@
     <string name="tea_time">Berenar</string>
 
     <!-- Recipe details -->
-    <string name="recipe_detail_time">Temps: %d minuts</string>
+    <string name="recipe_detail_minute_time">Temps: %d min</string>
+    <string name="recipe_detail_hour_time">Temps: %d h</string>
+    <string name="recipe_detail_hour_minute_time">Temps: %d h %d min</string>
     <string name="check_steps">Veure passos</string>
     <string name="favorite_recipe">Favorit</string>
     <string name="delete_recipe">Eliminar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -66,7 +66,9 @@
     <string name="tea_time">Merienda</string>
 
     <!-- Recipe details -->
-    <string name="recipe_detail_time">Tiempo: %d minutos</string>
+    <string name="recipe_detail_minute_time">Tiempo: %d min</string>
+    <string name="recipe_detail_hour_time">Tiempo: %d h</string>
+    <string name="recipe_detail_hour_minute_time">Tiempo: %d h %d min</string>
     <string name="check_steps">Ver pasos</string>
     <string name="favorite_recipe">Favorito</string>
     <string name="delete_recipe">Eliminar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,9 @@
     <string name="tea_time">Teatime</string>
 
     <!-- Recipe details -->
-    <string name="recipe_detail_time">Time: %d minutes</string>
+    <string name="recipe_detail_minute_time">Time: %d min</string>
+    <string name="recipe_detail_hour_time">Time: %d h</string>
+    <string name="recipe_detail_hour_minute_time">Time: %d h %d min</string>
     <string name="check_steps">Check recipe steps</string>
     <string name="favorite_recipe">Favorite</string>
     <string name="delete_recipe">Delete</string>


### PR DESCRIPTION
## Description
#### Summary of what has been done *
The time is expressed in minutes and it might be confusing. So it has been changed to hours and minutes, using their abbreviation

#### Reference issues *
Fixes the following issues:
 - Closes #1 , since the recipe time is now expressed in hours and minutes
 - Closes #8 , since the recipe time is now abbreviated, avoiding the need of singular and plural

## Type of change *
- [x] New feature (enhancement)
- [x] Bug fix
- [ ] Documentation update  
- [ ] Other (build scripts, metadata, assets, etc.)


## Checklist *
- [x] I have performed a self-review of my own code
- [x] My code is self-explanatory  
- [x] I have added all new string resources into strings.xml in all languages
- [x] All possible errors are properly handled  
- [x] I have tested the application with my changes and verify that all tests are passing
- [x] The documentation is up to date

## Testing notes
Go to any recipe details page and you should see the new time format

## Screenshots
![Screenshot_20210327-033401_Easy Recipe](https://user-images.githubusercontent.com/40755391/125609765-f27d6934-f991-4f81-aa6c-9e6298cb7c4c.jpg)
