### PR TITLE
Feature/create method to add multiple errors to text input layout

### DIFF
--- a/app/src/main/java/org/easyrecipe/common/extensions/TextInputLayoutExtensions.kt
+++ b/app/src/main/java/org/easyrecipe/common/extensions/TextInputLayoutExtensions.kt
@@ -85,3 +85,41 @@ fun TextInputLayout.observeExposedMenu(
         (editText as? AutoCompleteTextView)?.setAdapter(adapter)
     }
 }
+
+/**
+ * Observe the [TextInputLayout] for errors.
+ *
+ * @param lifecycleOwner The lifecycle of the fragment
+ * @param errorMsg The error message displayed in [TextInputLayout]
+ * @param liveData The [LiveData] to control whether the error should be displayed or not
+ */
+fun TextInputLayout.observeError(
+    lifecycleOwner: LifecycleOwner,
+    errorMsg: String,
+    liveData: LiveData<Boolean>,
+) {
+    liveData.observe(lifecycleOwner) { isDisplayed ->
+        showErrorIf(isDisplayed, errorMsg)
+    }
+}
+
+/**
+ * Observe multiple errors in a [TextInputLayout].
+ *
+ * @param lifecycleOwner The lifecycle of the fragment
+ * @param errors The errors that will be displayed, being the key an [Int] id and the value the
+ * message displayed
+ * @param liveData The [LiveData] to control which error should be displayed, and if null nothing
+ * will be shown
+ */
+fun TextInputLayout.observeMultipleErrors(
+    lifecycleOwner: LifecycleOwner,
+    errors: Map<Int, String>,
+    liveData: LiveData<Int?>,
+) {
+    liveData.observe(lifecycleOwner) { errorId ->
+        errorId?.let { currentErrorId ->
+            showErrorIf(true, errors[currentErrorId] ?: "")
+        } ?: showErrorIf(false, "")
+    }
+}

--- a/app/src/main/java/org/easyrecipe/common/extensions/TextInputLayoutExtensions.kt
+++ b/app/src/main/java/org/easyrecipe/common/extensions/TextInputLayoutExtensions.kt
@@ -118,8 +118,8 @@ fun TextInputLayout.observeMultipleErrors(
     liveData: LiveData<Int?>,
 ) {
     liveData.observe(lifecycleOwner) { errorId ->
-        errorId?.let { currentErrorId ->
-            showErrorIf(true, errors[currentErrorId] ?: "")
+        errors[errorId]?.let { errorMessage ->
+            showErrorIf(true, errorMessage)
         } ?: showErrorIf(false, "")
     }
 }

--- a/app/src/main/java/org/easyrecipe/data/Migrations.kt
+++ b/app/src/main/java/org/easyrecipe/data/Migrations.kt
@@ -36,7 +36,7 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
         val lastUpdate = System.currentTimeMillis()
         database.execSQL("alter table users add column last_update INTEGER default $lastUpdate")
-        database.execSQL("alter table users add column uid")
+        database.execSQL("alter table users add column uid TEXT")
     }
 }
 

--- a/app/src/main/java/org/easyrecipe/features/createrecipe/CreateRecipeViewModel.kt
+++ b/app/src/main/java/org/easyrecipe/features/createrecipe/CreateRecipeViewModel.kt
@@ -65,7 +65,11 @@ class CreateRecipeViewModel @Inject constructor(
     val ingredientQuantity = MutableLiveData("")
     private val predefinedIngredients = MutableLiveData<List<Ingredient>>()
     val predefinedIngredientsNames = predefinedIngredients.map { ingredients ->
-        ingredients.map { it.name.capitalize(Locale.getDefault()) }
+        ingredients.map { ingredient ->
+            ingredient.name.replaceFirstChar {
+                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+            }
+        }
     }
     val isIngredientInfoFilled =
         CombinedLiveData(ingredientName, ingredientQuantity) { name, quantity ->


### PR DESCRIPTION
## Description
#### Summary of what has been done *

- Add a method to display multiple errors in a `TextInputLayout`.

#### Reference issues *

Closes #31 

#### How it has been implemented

We have implemented two methods to observe errors within a `TextInputLayout`.
```kotlin
fun TextInputLayout.observeError(lifecycleOwner: LifecycleOwner, errorMsg: String, liveData: LiveData<Boolean>)
fun TextInputLayout.observeMultipleErrors(lifecycleOwner: LifecycleOwner, errors: Map<Int, String>, liveData: LiveData<Int?>)
```

On the one hand, the `observeError` method receives a `LiveData<Boolean>`, which controls whether the error should be displayed or not. On the other hand, the `observeMultipleError` receives a map containing the errors that should be displayed as follows:
- Key: `Int` that identifies the error and should be stored in a `companion object` inside the corresponding `ViewModel`.
- Value: The message to be displayed.

If the value of `LiveData<Int?>` is null or the error is not specified then the message will not appear.

## Type of change *
- [x] New feature (enhancement)
- [ ] Bug fix
- [x] Documentation update  
- [ ] Other (build scripts, metadata, assets, etc.)


## Checklist *
- [x] I have performed a self-review of my own code
- [x] My code is self-explanatory  
- [ ] I have added all new string resources into strings.xml in all languages
- [x] All possible errors are properly handled  
- [x] I have tested the application with my changes and verify that all tests are passing
- [x] The documentation is up to date
